### PR TITLE
Fix version file syntax

### DIFF
--- a/WheelSounds.version
+++ b/WheelSounds.version
@@ -17,7 +17,7 @@
         "MAJOR":0,
         "MINOR":23,
         "PATCH":0
-    }
+    },
     "KSP_VERSION_MAX":{
         "MAJOR":0,
         "MINOR":25,


### PR DESCRIPTION
The version file is missing a comma, which means some automated tools can't parse it.
Now it's fixed.